### PR TITLE
Reduce API calls via batching and caching

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,6 +12,15 @@ app.use(express.json());
 // In-memory storage (replace with a database in production)
 const events: Event[] = [];
 
+// Simple in-memory cache for public events
+let cachedEvents: { data: Event[]; expiry: number } | null = null;
+
+// Helper to load events - replace with database query in production
+const loadPublicEvents = async (): Promise<Event[]> => {
+  // In this demo the events array acts as our database
+  return events;
+};
+
 // Routes
 app.post('/events', (req, res) => {
   const eventData: CreateEventDto = req.body;
@@ -22,6 +31,23 @@ app.post('/events', (req, res) => {
   };
   events.push(newEvent);
   res.status(201).json(newEvent);
+});
+
+// Cached public events route
+app.get('/public-events', async (_req, res) => {
+  const now = Date.now();
+
+  if (cachedEvents && cachedEvents.expiry > now) {
+    return res.json(cachedEvents.data);
+  }
+
+  const data = await loadPublicEvents();
+  cachedEvents = {
+    data,
+    expiry: now + 60_000, // cache for 60 seconds
+  };
+
+  res.json(data);
 });
 
 app.get('/events/:id', (req, res) => {

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -244,16 +244,38 @@ export function UserProfile() {
       console.log('Found upcoming events after duration-aware filtering:', upcomingEvents.length)
       console.log('Found past events after duration-aware filtering:', pastEvents.length)
 
+      // Batch fetch creator profiles to avoid N+1 queries
+      const allCreatorIds = Array.from(new Set([
+        ...upcomingEvents,
+        ...pastEvents
+      ].map((e: any) => e.created_by).filter((id: string) => id !== user.id)))
+
+      let creatorProfileMap: Record<string, { display_name: string | null; nickname: string | null; avatar_url: string | null; user_id: string }> = {}
+      if (allCreatorIds.length > 0) {
+        try {
+          const { data: profiles } = await supabase
+            .from('user_profiles')
+            .select('display_name, nickname, avatar_url, user_id')
+            .in('user_id', allCreatorIds)
+
+          if (profiles) {
+            profiles.forEach(profile => {
+              creatorProfileMap[profile.user_id] = profile
+            })
+          }
+        } catch (error) {
+          console.error('Error batch fetching creator profiles:', error)
+        }
+      }
+
 
 
       // Transform upcoming events data for EventCard compatibility
-      let allUpcomingEvents = await Promise.all(upcomingEvents.map(async (event: any) => {
+      let allUpcomingEvents = upcomingEvents.map((event: any) => {
         const isHosting = event.created_by === user.id
 
-        // Get creator info for events not created by current user
         let creatorData
         if (isHosting) {
-          // Use current user's profile for events they created
           creatorData = {
             display_name: userProfile?.display_name || user?.email?.split('@')[0] || 'Unknown Host',
             nickname: userProfile?.nickname,
@@ -261,28 +283,12 @@ export function UserProfile() {
             user_id: user.id
           }
         } else {
-          // Fetch creator profile for events created by others
-          try {
-            const { data: creatorProfile } = await supabase
-              .from('user_profiles')
-              .select('display_name, nickname, avatar_url, user_id')
-              .eq('user_id', event.created_by)
-              .single()
-
-            creatorData = creatorProfile || {
-              display_name: `User ${event.created_by.slice(-4)}`,
-              nickname: null,
-              avatar_url: null,
-              user_id: event.created_by
-            }
-          } catch (error) {
-            console.error('Error fetching creator profile:', error)
-            creatorData = {
-              display_name: `User ${event.created_by.slice(-4)}`,
-              nickname: null,
-              avatar_url: null,
-              user_id: event.created_by
-            }
+          const profile = creatorProfileMap[event.created_by]
+          creatorData = profile || {
+            display_name: `User ${event.created_by.slice(-4)}`,
+            nickname: null,
+            avatar_url: null,
+            user_id: event.created_by
           }
         }
 
@@ -291,7 +297,7 @@ export function UserProfile() {
           creator: creatorData,
           isHosting
         }
-      }))
+      })
 
 
 
@@ -301,13 +307,11 @@ export function UserProfile() {
       setEnhancedSessions(allUpcomingEvents)
 
       // Transform past events data for EventCard compatibility
-      let allPastEvents = await Promise.all(pastEvents.map(async (event: any) => {
+      let allPastEvents = pastEvents.map((event: any) => {
         const isHosting = event.created_by === user.id
 
-        // Get creator info for events not created by current user
         let creatorData
         if (isHosting) {
-          // Use current user's profile for events they created
           creatorData = {
             display_name: userProfile?.display_name || user?.email?.split('@')[0] || 'Unknown Host',
             nickname: userProfile?.nickname,
@@ -315,28 +319,12 @@ export function UserProfile() {
             user_id: user.id
           }
         } else {
-          // Fetch creator profile for events created by others
-          try {
-            const { data: creatorProfile } = await supabase
-              .from('user_profiles')
-              .select('display_name, nickname, avatar_url, user_id')
-              .eq('user_id', event.created_by)
-              .single()
-
-            creatorData = creatorProfile || {
-              display_name: `User ${event.created_by.slice(-4)}`,
-              nickname: null,
-              avatar_url: null,
-              user_id: event.created_by
-            }
-          } catch (error) {
-            console.error('Error fetching creator profile:', error)
-            creatorData = {
-              display_name: `User ${event.created_by.slice(-4)}`,
-              nickname: null,
-              avatar_url: null,
-              user_id: event.created_by
-            }
+          const profile = creatorProfileMap[event.created_by]
+          creatorData = profile || {
+            display_name: `User ${event.created_by.slice(-4)}`,
+            nickname: null,
+            avatar_url: null,
+            user_id: event.created_by
           }
         }
 
@@ -345,7 +333,7 @@ export function UserProfile() {
           creator: creatorData,
           isHosting
         }
-      }))
+      })
 
       // Sort past events by date (descending - most recent first)
       allPastEvents.sort((a: any, b: any) => new Date(b.date_time).getTime() - new Date(a.date_time).getTime())


### PR DESCRIPTION
## Summary
- batch-load user profiles in `UserProfile` page instead of querying per event
- add cached `/public-events` route in Express backend

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b9e1ba410832996920ea67c713477