### PR TITLE
Refactor services to accept user context

### DIFF
--- a/frontend/src/components/EditEventModal.tsx
+++ b/frontend/src/components/EditEventModal.tsx
@@ -257,7 +257,7 @@ export function EditEventModal({ event, open, onOpenChange, onEventUpdated }: Ed
       // Add selected crew members if any (they automatically join)
       if (selectedInvitees.length > 0) {
         try {
-          await bulkAddCrewMembersToEvent(event.id, selectedInvitees)
+          await bulkAddCrewMembersToEvent(event.id, selectedInvitees, user!.id)
           toast.success(`🍺 Session updated and ${selectedInvitees.length} crew members invited!`)
         } catch (error) {
           console.error('Error inviting crew members:', error)

--- a/frontend/src/components/EventInvitationCard.tsx
+++ b/frontend/src/components/EventInvitationCard.tsx
@@ -4,11 +4,12 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
-import { 
-  respondToEventInvitation, 
+import {
+  respondToEventInvitation,
   showInvitationResponseToast,
-  type EventInvitation 
+  type EventInvitation
 } from '@/lib/eventInvitationService'
+import { useAuth } from '@/lib/auth-context'
 import { 
   Calendar, 
   MapPin, 
@@ -32,6 +33,7 @@ export function EventInvitationCard({ invitation, onResponse, showToast = true }
   const [showCommentBox, setShowCommentBox] = useState(false)
   const [comment, setComment] = useState('')
   const [pendingResponse, setPendingResponse] = useState<'accepted' | 'declined' | null>(null)
+  const { user } = useAuth()
 
   const handleResponse = async (response: 'accepted' | 'declined') => {
     if (isResponding) return
@@ -49,7 +51,7 @@ export function EventInvitationCard({ invitation, onResponse, showToast = true }
       const result = await respondToEventInvitation(invitation.invitation_id, {
         response,
         comment: comment.trim() || undefined
-      })
+      }, user!.id)
 
       if (result.success) {
         // Only show toast if showToast prop is true

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -91,7 +91,7 @@ export function NotificationBell() {
         return
       }
 
-      const result = await respondToEventInvitation(invitationId, { response })
+      const result = await respondToEventInvitation(invitationId, { response }, user!.id)
 
       if (result.success) {
         await markAsRead(notificationId)

--- a/frontend/src/components/NotificationCenter.tsx
+++ b/frontend/src/components/NotificationCenter.tsx
@@ -20,6 +20,7 @@ import { respondToEventInvitation } from '@/lib/eventService'
 import { toast } from 'sonner'
 import { Bell, Check, X, Users, Calendar, Eye } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
+import { useAuth } from '@/lib/auth-context'
 
 export function NotificationCenter() {
   const [notifications, setNotifications] = useState<Notification[]>([])
@@ -27,8 +28,10 @@ export function NotificationCenter() {
   const [isOpen, setIsOpen] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [respondedNotifications, setRespondedNotifications] = useState<Set<string>>(new Set())
+  const { user } = useAuth()
 
   useEffect(() => {
+    if (!user?.id) return
     loadNotifications()
     loadUnreadCount()
 
@@ -41,11 +44,12 @@ export function NotificationCenter() {
     }, 120000) // Changed from 30s to 2 minutes
 
     return () => clearInterval(interval)
-  }, [isOpen])
+  }, [isOpen, user?.id])
 
   const loadNotifications = async () => {
+    if (!user?.id) return
     try {
-      const data = await getNotifications()
+      const data = await getNotifications(user.id)
       setNotifications(data)
     } catch (error) {
       console.error('Error loading notifications:', error)
@@ -53,8 +57,9 @@ export function NotificationCenter() {
   }
 
   const loadUnreadCount = async () => {
+    if (!user?.id) return
     try {
-      const count = await getUnreadNotificationCount()
+      const count = await getUnreadNotificationCount(user.id)
       setUnreadCount(count)
     } catch (error) {
       console.error('Error loading unread count:', error)
@@ -75,8 +80,9 @@ export function NotificationCenter() {
 
   const handleMarkAllAsRead = async () => {
     try {
+      if (!user?.id) return
       setIsLoading(true)
-      await markAllNotificationsAsRead()
+      await markAllNotificationsAsRead(user.id)
       setNotifications(prev => prev.map(n => ({ ...n, read: true })))
       setUnreadCount(0)
       toast.success('All notifications marked as read')

--- a/frontend/src/components/QuickEventModal.tsx
+++ b/frontend/src/components/QuickEventModal.tsx
@@ -256,7 +256,7 @@ export function QuickEventModal({ onEventCreated, trigger }: QuickEventModalProp
             crewMembers: crewMembers.length
           })
 
-          const invitationResult = await sendEventInvitationsToCrew(createdEventId, selectedCrew)
+          const invitationResult = await sendEventInvitationsToCrew(createdEventId, selectedCrew, user!.id)
 
           if (invitationResult.success && invitationResult.invitedCount > 0) {
             invitationMessage = ` ${invitationResult.message}`


### PR DESCRIPTION
## Summary
- update follow, member and event invitation services to require the current user id
- pass the current user from components to these services
- remove internal `supabase.auth.getUser()` calls

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bb3eab0188329bebe6eded25479df