### PR TITLE
Reduce frequent auth requests

### DIFF
--- a/AUTH_REQUEST_FREQUENCY_FIX_SUMMARY.md
+++ b/AUTH_REQUEST_FREQUENCY_FIX_SUMMARY.md
@@ -1,0 +1,14 @@
+# Excessive Auth Requests Fix
+
+## Problem
+- Continuous GET requests to `/auth/v1/user` were observed almost every second.
+- These were caused by numerous `supabase.auth.getUser()` calls throughout the frontend services.
+- `getUser()` always hits the Supabase API, so repeated calls flood the network and logs.
+
+## Solution
+- Replaced all frontend usages of `supabase.auth.getUser()` with a session-based helper `getCurrentUser()` from `authUtils`.
+- `getCurrentUser()` relies on `supabase.auth.getSession()` which reads from local storage and avoids an API call.
+- Updated imports in affected service modules: `eventMediaService`, `crewService`, `eventService`, `userService`, `eventRatingService`, `runMigration`, and `googleAvatarService`.
+
+## Result
+- Auth queries now rely on cached session data, eliminating the per-second requests to `/auth/v1/user`.

--- a/frontend/src/lib/crewService.ts
+++ b/frontend/src/lib/crewService.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase'
+import { getCurrentUser } from './authUtils'
 import type { Crew, CrewMember, CreateCrewData } from '@/types'
 import { generateTokenizedUrls } from './invitationTokenService'
 
@@ -21,7 +22,7 @@ const debugError = (...args: any[]) => {
 // Get user's crews (where they are a member)
 export async function getUserCrews(userId?: string): Promise<Crew[]> {
   try {
-    const { data: { user } } = await supabase.auth.getUser()
+    const user = await getCurrentUser()
     const currentUserId = userId || user?.id
     if (!currentUserId) {
       return []
@@ -114,7 +115,7 @@ export async function getUserCrews(userId?: string): Promise<Crew[]> {
 
 // Create a new crew
 export async function createCrew(data: CreateCrewData): Promise<Crew> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) throw new Error('Not authenticated')
 
   const { data: crew, error } = await supabase
@@ -132,7 +133,7 @@ export async function createCrew(data: CreateCrewData): Promise<Crew> {
 
 // Get crew details by ID
 export async function getCrewById(crewId: string): Promise<Crew | null> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
 
   const { data, error } = await supabase
     .from('crews')
@@ -451,7 +452,7 @@ async function sendCrewInvitationEmailToUser(crewId: string, userId: string, inv
 
 // Invite user to crew by user ID
 export async function inviteUserToCrew(crewId: string, userId: string): Promise<void> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) throw new Error('Not authenticated')
 
   const { data: invitation, error } = await supabase
@@ -541,7 +542,7 @@ export async function respondToCrewInvitation(crewMemberId: string, status: 'acc
 
 // Get pending crew invitations for current user
 export async function getPendingCrewInvitations(): Promise<Array<CrewMember & { crew: Crew }>> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) return []
 
   const { data, error } = await supabase
@@ -573,7 +574,7 @@ export async function getPendingCrewInvitations(): Promise<Array<CrewMember & { 
 
 // Create shareable invite link
 export async function createCrewInviteLink(crewId: string, expiresInDays?: number, maxUses?: number): Promise<string> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) throw new Error('Not authenticated')
 
   // Generate unique invite code
@@ -632,7 +633,7 @@ export async function createCrewInviteLink(crewId: string, expiresInDays?: numbe
 
 // Join crew via invite code
 export async function joinCrewByInviteCode(inviteCode: string): Promise<Crew> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) throw new Error('Not authenticated')
 
   console.log('Looking up invite code:', inviteCode)
@@ -707,7 +708,7 @@ export async function joinCrewByInviteCode(inviteCode: string): Promise<Crew> {
 
 // Leave crew
 export async function leaveCrew(crewId: string): Promise<void> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) throw new Error('Not authenticated')
 
   const { error } = await supabase
@@ -734,7 +735,7 @@ export async function removeMemberFromCrew(crewId: string, userId: string): Prom
 export async function searchUsersForInvite(query: string, crewId?: string): Promise<Array<{ user_id: string; display_name: string; avatar_url: string | null; email?: string }>> {
   if (!query.trim()) return []
 
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) return []
 
   console.log('🔍 Searching for users with query:', query)
@@ -819,7 +820,7 @@ export async function searchUsersForInvite(query: string, crewId?: string): Prom
 
 // Update crew
 export async function updateCrew(crewId: string, updates: Partial<Crew>): Promise<void> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) throw new Error('Not authenticated')
 
   const { error } = await supabase
@@ -836,7 +837,7 @@ export async function updateCrew(crewId: string, updates: Partial<Crew>): Promis
  */
 export async function deleteCrew(crewId: string): Promise<boolean> {
   try {
-    const { data: { user } } = await supabase.auth.getUser()
+    const user = await getCurrentUser()
     if (!user) throw new Error('Not authenticated')
 
     console.log('🗑️ Deleting crew:', crewId)

--- a/frontend/src/lib/eventMediaService.ts
+++ b/frontend/src/lib/eventMediaService.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase'
+import { getCurrentUser } from './authUtils'
 import { uploadFile } from './fileUpload'
 import { cache, CACHE_KEYS } from './cache'
 import type { EventPhoto, EventComment, EventCommentReaction } from '@/types'
@@ -79,7 +80,7 @@ export async function uploadEventPhoto(
   file: File,
   caption?: string
 ): Promise<EventPhoto> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
 
   if (!user) {
     throw new Error('User not authenticated')
@@ -138,7 +139,7 @@ export async function uploadEventPhoto(
  * Get all photos for an event
  */
 export async function getEventPhotos(eventId: string): Promise<EventPhoto[]> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
 
   if (!user) {
     throw new Error('User not authenticated')
@@ -188,7 +189,7 @@ export async function getEventPhotos(eventId: string): Promise<EventPhoto[]> {
  * Delete an event photo
  */
 export async function deleteEventPhoto(photoId: string): Promise<void> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
 
   if (!user) {
     throw new Error('User not authenticated')
@@ -236,7 +237,7 @@ export async function deleteEventPhoto(photoId: string): Promise<void> {
  * Add a comment to an event
  */
 export async function addEventComment(eventId: string, content: string): Promise<EventComment> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
 
   if (!user) {
     throw new Error('User not authenticated')
@@ -284,7 +285,7 @@ export async function addEventComment(eventId: string, content: string): Promise
  * Get all comments for an event
  */
 export async function getEventComments(eventId: string): Promise<EventComment[]> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
 
   if (!user) {
     throw new Error('User not authenticated')
@@ -345,7 +346,7 @@ export async function addCommentReaction(
   commentId: string,
   reaction: EventCommentReaction['reaction']
 ): Promise<void> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
 
   if (!user) {
     throw new Error('User not authenticated')
@@ -376,7 +377,7 @@ export async function removeCommentReaction(
   commentId: string,
   reaction: EventCommentReaction['reaction']
 ): Promise<void> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
 
   if (!user) {
     throw new Error('User not authenticated')

--- a/frontend/src/lib/eventRatingService.ts
+++ b/frontend/src/lib/eventRatingService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase'
+import { getCurrentUser } from './authUtils'
 import type { EventRating } from '@/types'
 
 /**
@@ -9,7 +10,7 @@ export async function submitEventRating(
   rating: number,
   feedbackText?: string | null
 ): Promise<EventRating> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) {
     throw new Error('You must be signed in to rate events')
   }
@@ -94,7 +95,7 @@ export async function submitEventRating(
  * Get user's rating for a specific event
  */
 export async function getUserEventRating(eventId: string): Promise<EventRating | null> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) return null
 
   const { data, error } = await supabase
@@ -166,7 +167,7 @@ export async function getEventRatingStats(eventId: string): Promise<{
  */
 export async function canUserRateEvent(eventId: string, userId?: string): Promise<boolean> {
   if (!userId) {
-    const { data: { user } } = await supabase.auth.getUser()
+    const user = await getCurrentUser()
     if (!user) return false
     userId = user.id
   }
@@ -212,7 +213,7 @@ export async function canUserRateEvent(eventId: string, userId?: string): Promis
  * Delete a user's rating for an event
  */
 export async function deleteEventRating(eventId: string): Promise<void> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) {
     throw new Error('You must be signed in to delete ratings')
   }
@@ -256,7 +257,7 @@ export async function hasEventConcluded(eventId: string): Promise<boolean> {
  */
 export async function getUnratedAttendedEvents(userId?: string): Promise<any[]> {
   if (!userId) {
-    const { data: { user } } = await supabase.auth.getUser()
+    const user = await getCurrentUser()
     if (!user) return []
     userId = user.id
   }

--- a/frontend/src/lib/eventService.ts
+++ b/frontend/src/lib/eventService.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase'
+import { getCurrentUser } from './authUtils'
 import type { Event, RsvpStatus, UserProfile } from '@/types'
 import { getDefaultCoverImage } from './coverImageUtils'
 import { getEventRatingStats } from '@/lib/eventRatingService'
@@ -347,8 +348,9 @@ export async function createEventWithShareableLink(eventData: {
   }
 }) {
   // Get the current user
-  const { data: { user }, error: userError } = await supabase.auth.getUser()
-  if (userError || !user) {
+  const user = await getCurrentUser()
+  const userError = null
+  if (!user) {
     throw new Error('Not authenticated')
   }
 
@@ -494,11 +496,9 @@ export async function getPublicEvents(): Promise<Event[]> {
     }
 
     // Get current user (this is optional for public events)
-    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    const user = await getCurrentUser()
 
-    if (userError) {
-      // Continue without user data if there's an error
-    }
+    // Continue without user data if there's an error (no error expected with getCurrentUser)
 
     // If user is logged in and has valid ID, check which events they've joined
     let userRsvps: any[] = []
@@ -654,7 +654,7 @@ export async function getUserAccessibleEvents() {
 // Respond to event invitation (accept/decline)
 export async function respondToEventInvitation(eventMemberId: string, response: 'accepted' | 'declined') {
   try {
-    const { data: { user } } = await supabase.auth.getUser()
+    const user = await getCurrentUser()
 
     if (!user) {
       throw new Error('User authentication required')
@@ -700,7 +700,7 @@ export async function updateEvent(id: string, event: Partial<Event>) {
  */
 export async function deleteEvent(id: string): Promise<boolean> {
   try {
-    const { data: { user } } = await supabase.auth.getUser()
+    const user = await getCurrentUser()
     if (!user) throw new Error('Not authenticated')
 
     console.log('🗑️ Deleting event:', id)

--- a/frontend/src/lib/googleAvatarService.ts
+++ b/frontend/src/lib/googleAvatarService.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase'
+import { getCurrentUser } from './authUtils'
 
 /**
  * Service for handling Google avatar URLs from OAuth metadata
@@ -43,7 +44,7 @@ export async function getGoogleAvatarUrl(userId: string): Promise<string | null>
  */
 export async function getCurrentUserGoogleAvatar(): Promise<string | null> {
   try {
-    const { data: { user } } = await supabase.auth.getUser()
+    const user = await getCurrentUser()
 
     if (!user) {
       return null

--- a/frontend/src/lib/runMigration.ts
+++ b/frontend/src/lib/runMigration.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase'
+import { getCurrentUser } from './authUtils'
 
 export async function runPrivacyMigration() {
   try {
@@ -91,7 +92,7 @@ export async function runPrivacyMigration() {
 // Helper function to create a user profile for current user
 export async function createCurrentUserProfile() {
   try {
-    const { data: { user } } = await supabase.auth.getUser()
+    const user = await getCurrentUser()
     if (!user) throw new Error('No authenticated user')
 
     const displayName = user.email?.split('@')[0] || 'User'

--- a/frontend/src/lib/userService.ts
+++ b/frontend/src/lib/userService.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase'
+import { getCurrentUser } from './authUtils'
 import type { UserProfile, UserFollow } from '@/types'
 import { withCache, CACHE_KEYS, invalidateUserCaches } from './cache'
 
@@ -286,7 +287,7 @@ export async function ensureUserProfileExists(user: any, maxRetries = 3): Promis
 
 // Follow Functions
 export async function followUser(followingId: string) {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) throw new Error('Not authenticated')
 
   const { data, error } = await supabase
@@ -303,7 +304,7 @@ export async function followUser(followingId: string) {
 }
 
 export async function unfollowUser(followingId: string) {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) throw new Error('Not authenticated')
 
   const { error } = await supabase
@@ -375,7 +376,7 @@ export async function getFollowCounts(userId: string) {
 }
 
 export async function isFollowing(followingId: string): Promise<boolean> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) return false
 
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- avoid API calls by using `getCurrentUser` instead of `supabase.auth.getUser`
- add `getCurrentUser` imports across services
- document the fix

## Testing
- `npm run build` *(fails: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists)*

------
https://chatgpt.com/codex/tasks/task_e_685bbeddc720832985eb77e5db4f691d