### PR TITLE
Fix event duration type on insert

### DIFF
--- a/frontend/src/components/QuickEventModal.tsx
+++ b/frontend/src/components/QuickEventModal.tsx
@@ -209,6 +209,8 @@ export function QuickEventModal({ onEventCreated, trigger }: QuickEventModalProp
         longitude: formData.locationData?.longitude || null,
         place_id: formData.locationData?.place_id || null,
         place_name: formData.locationData?.place_name || null,
+        // Explicitly set duration_type to satisfy database constraint
+        duration_type: 'specific_time',
         date_time: (() => {
           if (formData.time === 'custom' && formData.start_time) {
             return new Date(formData.start_time).toISOString();

--- a/frontend/src/lib/eventService.ts
+++ b/frontend/src/lib/eventService.ts
@@ -307,7 +307,9 @@ export async function createEvent(event: Omit<Event, 'id' | 'created_at' | 'upda
   // Assign default cover image if not provided
   const eventWithCover = {
     ...event,
-    cover_image_url: event.cover_image_url || getDefaultCoverImage(event.vibe)
+    cover_image_url: event.cover_image_url || getDefaultCoverImage(event.vibe),
+    // Provide a default duration_type in case the DB lacks a default value
+    duration_type: 'specific_time'
   }
 
   const { data, error } = await supabase
@@ -407,6 +409,8 @@ export async function createEventWithShareableLink(eventData: {
       place_id: eventData.locationData?.place_id,
       place_name: eventData.locationData?.place_name,
       date_time: eventData.date_time,
+      // Ensure duration_type always has a valid value
+      duration_type: 'specific_time',
       drink_type: eventData.drink_type,
       vibe: eventData.vibe,
       notes: eventData.notes,


### PR DESCRIPTION
## Summary
- set `duration_type` when creating new events to avoid constraint errors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d45c80e188329bbad82aef44af08c